### PR TITLE
Add explicit column name

### DIFF
--- a/sqlalchemy_batch_inserts/__init__.py
+++ b/sqlalchemy_batch_inserts/__init__.py
@@ -40,7 +40,7 @@ def _has_normal_id_primary_key(base_mapper, column="id"):
 
 
 def _get_id_sequence_name(base_mapper, column="id"):
-    assert _has_normal_id_primary_key(base_mapper), "_get_id_sequence_name only supports id primary keys"
+    assert _has_normal_id_primary_key(base_mapper, column=column), f"_get_id_sequence_name only supports {column} primary keys"
     return "%s_%s_seq" % (base_mapper.entity.__tablename__, column)
 
 
@@ -55,7 +55,7 @@ def _get_next_sequence_values(session, base_mapper, num_values, column="id"):
     `_get_next_sequence_values(session, Model.__mapper__, 5)` will return [12, 13, 14, 15, 16].
     """
     assert _has_normal_id_primary_key(
-        base_mapper
+        base_mapper, column=column
     ), "_get_next_sequence_values assumes that the sequence produces integer values"
 
     id_seq_name = _get_id_sequence_name(base_mapper, column=column)


### PR DESCRIPTION
Hi,

(This is the same person as andrewcooke - I was previously using your library in a personal project (and filed an incorrect bug report), but am now using it at work).

I am working on a database loading project that *halves* loading time with this library (thank-you very much!).  Unfortunately, the primary key columns are called 'rowid' rather than 'id' (the object model includes 'id' attributes/columns so we had to use another name).

I have patched your code to take an additional argument (column, default "id" as before) that specifies the column name and modified the necessary logic to use the dynamically-named attribute.  The changes are minimal.

A quick test using 'demo' showed a very small impact to speed:
<pre>
[before] $ ./demo.py yes 10000
took 2.490032434463501 seconds
have 10000 users
have 20000 addresses
[after] $ ./demo.py yes 10000
took 2.5225682258605957 seconds
have 10000 users
have 20000 addresses
</pre>

That's a change of 1% and close to the error in repeated measurements.

Please can you consider including this in your own code?  It would simplify install and maintenance for our client.

(If you want, I can try a more complicated fix where a 'None' column name uses the id attributes directly, but the code will be messier and I doubt it's worth the possible speed-up in the default case)

Thanks,
Andrew

PS Although I've used github for years I've never done a pull request via this interface before - I hope everything is OK.