### PR TITLE
Fix table schema location

### DIFF
--- a/sqlalchemy_batch_inserts/__init__.py
+++ b/sqlalchemy_batch_inserts/__init__.py
@@ -59,7 +59,9 @@ def _get_next_sequence_values(session, base_mapper, num_values):
     ), "_get_next_sequence_values assumes that the sequence produces integer values"
 
     id_seq_name = _get_id_sequence_name(base_mapper)
-    schema = base_mapper.entity.__table__.metadata.schema
+    # Table.schema is the canonical place to get the name of the schema.
+    # See https://docs.sqlalchemy.org/en/13/core/metadata.html#sqlalchemy.schema.Table.params.schema
+    schema = base_mapper.entity.__table__.schema
     sequence = sqlalchemy.Sequence(id_seq_name, schema=schema)
 
     # Select the next num_values from `sequence`


### PR DESCRIPTION
The canonical place to find the schema in all cases is `Table.schema`, as it will inherit the schema name from its owning `MetaData` object if no explicit schema is set. See https://docs.sqlalchemy.org/en/13/core/metadata.html#sqlalchemy.schema.Table.params.schema for details.